### PR TITLE
Fix guzzlehttp/psr7 2.x compatibility and update

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     },
     "require": {
         "php": ">=7.3",
-        "guzzlehttp/psr7": "^1.4",
+        "guzzlehttp/psr7": "^2.0.0",
         "psr/log": "^1.0|^2.0|^3.0"
     },
     "require-dev": {

--- a/src/Handler/CurlRequestHandler.php
+++ b/src/Handler/CurlRequestHandler.php
@@ -192,7 +192,7 @@ class CurlRequestHandler implements RequestHandler
     protected function parseResponse($message)
     {
         try {
-            return \GuzzleHttp\Psr7\parse_response($message);
+            return \GuzzleHttp\Psr7\Message::parseResponse($message);
         } catch (\InvalidArgumentException $e) {
             throw ParseResponseException::create($e);
         }


### PR DESCRIPTION
Allow `guzzlehttp/psr7 ^2.0.0` and replace use of deprecated `\GuzzleHttp\Psr7\parse_response()`